### PR TITLE
Support multiple modems

### DIFF
--- a/config_server.py
+++ b/config_server.py
@@ -37,7 +37,6 @@ class DreamPiConfigurationService(BaseHTTPRequestHandler):
             "is_enabled": enabled_state
         }))
 
-
     def do_POST(self):
         enabled_state = True
 
@@ -64,12 +63,14 @@ class DreamPiConfigurationService(BaseHTTPRequestHandler):
 server = None
 thread = None
 
+
 def start():
     global server
     global thread
     server = HTTPServer(('0.0.0.0', 1998), DreamPiConfigurationService)
     thread = threading.Thread(target=server.serve_forever)
     thread.start()
+
 
 def stop():
     global server

--- a/dcnow.py
+++ b/dcnow.py
@@ -39,7 +39,7 @@ class DreamcastNowThread(threading.Thread):
             if not self._service._enabled:
                 return
 
-            lines = [ x for x in sh.tail("/var/log/syslog", "-n", "10", _iter=True) ]
+            lines = [x for x in sh.tail("/var/log/syslog", "-n", "10", _iter=True)]
             dns_query = None
             for line in lines[::-1]:
                 if "CONNECT" in line and "dreampi" in line:
@@ -54,7 +54,7 @@ class DreamcastNowThread(threading.Thread):
                     break
 
             user_agent = 'Mozilla/4.0 (compatible; MSIE 5.5; Windows NT), Dreamcast Now'
-            header = { 'User-Agent' : user_agent }
+            header = {'User-Agent': user_agent}
             mac_address = self._service._mac_address
             data = {}
             if dns_query:
@@ -62,7 +62,7 @@ class DreamcastNowThread(threading.Thread):
 
             data = urllib.urlencode(data)
             req = urllib2.Request(API_ROOT + UPDATE_END_POINT.format(mac_address=mac_address), data, header)
-            urllib2.urlopen(req) # Send POST update
+            urllib2.urlopen(req)  # Send POST update
 
         while self._running:
             try:

--- a/dreampi.py
+++ b/dreampi.py
@@ -544,8 +544,9 @@ def process():
 
     # Initial cleanup: old processes and config files
     with open(os.devnull, 'wb') as devnull:
-        subprocess.call(["sudo", "rm", "/etc/ppp/peers/dreamcast*", "/var/run/ppp-dreamcast*.pid"],
-                        stderr=devnull, shell=True)
+        # use sh -c to delay eval instead of shell=True; globbing would be expanded with the current user otherwise
+        subprocess.call(["sudo", "sh", "-c", "rm /etc/ppp/peers/dreamcast* /var/run/ppp-dreamcast*.pid"],
+                        stderr=devnull)
     # Make sure pppd isn't running
     with open(os.devnull, 'wb') as devnull:
         subprocess.call(["sudo", "killall", "pppd"], stderr=devnull)

--- a/dreampi.py
+++ b/dreampi.py
@@ -585,12 +585,13 @@ def process():
 
         modem = Modem(device['device'], device['speed'], dial_tone_enabled)
 
-        # Get a port forwarding object, now that we know the DC IP.
-        # port_forwarding = PortForwarding(dreamcast_ip, logger)
+        # if len(devices) == 1:
+            # Get a port forwarding object, now that we know the DC IP.
+            # port_forwarding = PortForwarding(dreamcast_ip, logger)
 
-        # Disabled until we can figure out a faster way of doing this.. it takes a minute
-        # on my router which is way too long to wait for the DreamPi to boot
-        # port_forwarding.forward_all()
+            # Disabled until we can figure out a faster way of doing this.. it takes a minute
+            # on my router which is way too long to wait for the DreamPi to boot
+            # port_forwarding.forward_all()
 
         mode = "LISTENING"
 
@@ -659,8 +660,9 @@ def process():
                 if dial_tone_enabled:
                     modem.start_dial_tone()
 
-        # Temporarily disabled, see above
-        # port_forwarding.delete_all()
+        # if len(devices) == 1:
+            # Temporarily disabled, see above
+            # port_forwarding.delete_all()
     return 0
 
 

--- a/dreampi.py
+++ b/dreampi.py
@@ -240,17 +240,17 @@ noccp
         f.write(options_content)
 
 
-ENABLE_SPEED_DETECTION = False  # Set this to true if you want to use wvdialconf for device detection
+ENABLE_MODEM_DETECTION = False  # Set this to true if you want to use wvdialconf for device detection
 FORCE_TWO_MODEMS = False        # experimental: force dreampi to consider two modem devices without running wvdialconf
 
 
 # detect_devices_and_speed will run wvdialconf to detect any number of modem devices and their associated
 # speed.
-# wvdialconf can be prolematic with recent Pi models, as such it is disabled by default, using a single
+# wvdialconf can be problematic with recent Pi models, as such it is disabled by default, using a single
 # default modem device (ttyACM0).
-# wvdialconf can be re-enabled by setting ENABLE_SPEED_DETECTION to True,
+# wvdialconf can be re-enabled by setting ENABLE_MODEM_DETECTION to True,
 # or if you still want to bypass the autodetection but try to use two modems, you can set
-# FORCE_DOUBLE_MODEM to True. (the second modem device will be ttyACM1 by default).
+# FORCE_TWO_MODEMS to True. (the second modem device will be ttyACM1 by default).
 def detect_devices_and_speed():
     MAX_SPEED = 57600
 
@@ -260,7 +260,7 @@ def detect_devices_and_speed():
     # https://github.com/lurch/rpi-serial-console/blob/master/rpi-serial-console
     # https://elinux.org/RPi_Serial_Connection
     # ?
-    if not ENABLE_SPEED_DETECTION:
+    if not ENABLE_MODEM_DETECTION:
         # By default we don't detect the speed or device as it's flakey in later
         # Pi kernels. But it might be necessary for some people so that functionality
         # can be enabled by setting the flag above to True

--- a/dreampi.py
+++ b/dreampi.py
@@ -18,7 +18,8 @@ import urllib2
 import iptc
 
 from dcnow import DreamcastNowService
-from port_forwarding import PortForwarding
+# unused for now
+# from port_forwarding import PortForwarding
 
 from datetime import datetime, timedelta
 
@@ -227,7 +228,8 @@ noccp
 
         logger.info("Dreamcast IP: {}".format(dreamcast_ip))
 
-        peers_content = PEERS_TEMPLATE.format(device=device['device'], device_speed=device['speed'], this_ip=this_ip, dc_ip=dreamcast_ip, device_name=device['name'])
+        peers_content = PEERS_TEMPLATE.format(device=device['device'], device_speed=device['speed'],
+                                              this_ip=this_ip, dc_ip=dreamcast_ip, device_name=device['name'])
 
         with open("/etc/ppp/peers/"+device['name'], "w") as f:
             f.write(peers_content)
@@ -239,7 +241,7 @@ noccp
 
 
 ENABLE_SPEED_DETECTION = False  # Set this to true if you want to use wvdialconf for device detection
-FORCE_TWO_MODEMS = False # experimental feature: force dreampi to consider two modem devices without running wvdialconf
+FORCE_TWO_MODEMS = False        # experimental: force dreampi to consider two modem devices without running wvdialconf
 
 
 # detect_devices_and_speed will run wvdialconf to detect any number of modem devices and their associated

--- a/port_forwarding.py
+++ b/port_forwarding.py
@@ -1,5 +1,6 @@
 import miniupnpc
 
+
 class PortForwarding:
     """
         This class is used to forward the ports of all supported Dreamcast games


### PR DESCRIPTION
Trying to get 2 dreamcasts online with a single raspberry pi with this experimental patch.

- wvdialconf will consolidate a list of modem devices (can be forced to 2 to skip it)
- in case of multiple devices, pppd peer files are suffixed (`dreamcast1`, `dreamcast2`, ...)
- each device has its own fork running the main loop, the last one keeps the parent process
- pppd peer files carry a `linkname` option, to retrieve their pidfile in `/var/run/ppp-$linkname.pid`
- `Modem hangup` messages are filtered by pppd pid so only that device's loop will consider it

Overall-- if the experimental patch is not activated, the behavior should be strictly identical to dreampi 1.7.x

Misc fixes to other parts to make the linter happy.

DCNow is kind of broken with multiple dreamcasts since they will override each other.
Possibly:
1. it doesnt matter
2. the dns spy can somehow trace back the dreamcast issuing the dns request and include it as part of the payload


:heavy_exclamation_mark: ~~this code is **UNTESTED** as of now, killing time while waiting for my dreampi parts to ship ;)~~

**Tested successfully with 2x modems + 2x voltage inducers + 2x dreamcasts and a single RPi2, playing PSO** :heavy_exclamation_mark: